### PR TITLE
Avoiding constant error when daemon kit is not loaded 

### DIFF
--- a/lib/dotenv/daemon_kit.rb
+++ b/lib/dotenv/daemon_kit.rb
@@ -1,1 +1,2 @@
+require "daemon_kit/initializer"
 Dotenv.load ".env.#{DaemonKit.env}", ".env"


### PR DESCRIPTION
In order to avoid uninitialized constant when dotenv is required before daemon_kit. E.g: `bundle console`

Requiring daemon kit here